### PR TITLE
adding custom keyserver for phive installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ jobs:
 #### phive-arguments
 PHIVE Install Action always passes the `--copy` option to the PHIVE `install` command.
 If you want to pass additional options or arguments, you can use the `phive-arguments` input parameter.
+Since some sks servers have been shut down there needs to be an option to customize the keyserver for the phive installation. You can use the `phive-keyserver` input parameter.
 
 For example:
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
   using: 'composite'
   steps:
     - name: 'Install PHIVE'
-      run: ${{ github.action_path }}/src/utils/retry.sh ${{ github.action_path }}/src/phive/install.sh ${{ inputs.phive-keyserver:-hkps://keyserver.ubuntu.com }}
+      run: ${{ github.action_path }}/src/utils/retry.sh ${{ github.action_path }}/src/phive/install.sh ${{ inputs.phive-keyserver }}
       shell: 'bash'
       # TODO: When "uses" becomes available, replace the above with the following
       #    - name: 'Install PHIVE'

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
   using: 'composite'
   steps:
     - name: 'Install PHIVE'
-      run: ${{ github.action_path }}/src/utils/retry.sh ${{ github.action_path }}/src/phive/install.sh
+      run: ${{ github.action_path }}/src/utils/retry.sh ${{ github.action_path }}/src/phive/install.sh ${{ inputs.phive-keyserver:-hkps://keyserver.ubuntu.com }}
       shell: 'bash'
       # TODO: When "uses" becomes available, replace the above with the following
       #    - name: 'Install PHIVE'

--- a/src/phive/install.sh
+++ b/src/phive/install.sh
@@ -1,9 +1,10 @@
 #/bin/bash
-
 set -Ceuo pipefail
+
+if [ "${1+defined}" = defined ]; then KEYSERVER=$1; else KEYSERVER=hkps://keyserver.ubuntu.com; fi
 
 wget -O phive.phar https://phar.io/releases/phive.phar
 wget -O phive.phar.asc https://phar.io/releases/phive.phar.asc
-gpg --keyserver $* --recv-keys 0x9D8A98B29B2D5D79
+gpg --keyserver ${KEYSERVER} --recv-keys 0x9D8A98B29B2D5D79
 gpg --verify phive.phar.asc phive.phar
 chmod +x phive.phar

--- a/src/phive/install.sh
+++ b/src/phive/install.sh
@@ -4,6 +4,6 @@ set -Ceuo pipefail
 
 wget -O phive.phar https://phar.io/releases/phive.phar
 wget -O phive.phar.asc https://phar.io/releases/phive.phar.asc
-gpg --keyserver pool.sks-keyservers.net --recv-keys 0x9D8A98B29B2D5D79
+gpg --keyserver $* --recv-keys 0x9D8A98B29B2D5D79
 gpg --verify phive.phar.asc phive.phar
 chmod +x phive.phar


### PR DESCRIPTION
Hey there, 
I think this would be a fitting solution to enable users to customize the keyserver for the installation of phive. 
This would be a fine enhancement of the action. At the moment pipelines crash since the default sks server in the install.sh is not reachable. You could just replace the server there with a reachable one. But any hardcoded server there could potentially be shut down in future. So it would be cool to customize this. A default value will still be set if no customization is made.

Please feel free to give me feedback for this PR. If it fits you, I would be glad if you would merge it.

Greetings
Kuni
